### PR TITLE
Update stake-stream.clar

### DIFF
--- a/contracts/stake-stream.clar
+++ b/contracts/stake-stream.clar
@@ -307,6 +307,32 @@
     )
 )
 
+;; Allows users to claim accumulated rewards
+(define-public (claim-rewards)
+  (let
+      (
+          (staking-position (unwrap! (map-get? StakingPositions tx-sender) ERR-NO-STAKE))
+          (user-position (unwrap! (map-get? UserPositions tx-sender) ERR-NOT-AUTHORIZED))
+      )
+      (let (
+            (blocks-staked (- stacks-block-height (get last-claim staking-position)))
+            (rewards (calculate-rewards tx-sender blocks-staked))
+          )
+          ;; Update staking position
+          (map-set StakingPositions
+              tx-sender
+              (merge staking-position { last-claim: stacks-block-height, accumulated-rewards: (+ (get accumulated-rewards staking-position) rewards) })
+          )
+
+          ;; Transfer ANALYTICS-TOKEN as reward (or STX)
+          (try! (ft-mint? ANALYTICS-TOKEN rewards tx-sender))
+
+          (ok rewards)
+      )
+  )
+)
+
+
 ;; read only functions
 
 ;; Returns the contract owner


### PR DESCRIPTION
feat: add reward claiming function for stakers

- Introduced a public `claim-rewards` function allowing users to claim accumulated staking rewards.
- Calculates rewards based on staked amount, tier multiplier, and elapsed blocks since last claim.
- Updates staking positions with the last claim block and accumulated rewards.
- Mints ANALYTICS-TOKEN (or other reward token) to users upon successful claim.
- Enhances user engagement by providing an acti