### PR TITLE
Update stake-stream.test.ts

### DIFF
--- a/tests/stake-stream.test.ts
+++ b/tests/stake-stream.test.ts
@@ -18,4 +18,47 @@ describe("example tests", () => {
   //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
   //   expect(result).toBeUint(0);
   // });
+  it("allows a user to claim rewards after staking", async () => {
+    // Step 1: Stake STX first
+    const stakeAmount = 1000000; // 1M uSTX
+    const lockPeriod = 0;         // no lock
+    await simnet.mineBlock([
+      simnet.tx.contractCall({
+        contractAddress: address1,
+        contractName: "stakestream",
+        functionName: "stake-stx",
+        functionArgs: [
+          simnet.types.uint(stakeAmount),
+          simnet.types.uint(lockPeriod),
+        ],
+        sender: address1,
+      }),
+    ]);
+
+    // Step 2: Move forward some blocks to accumulate rewards
+    await simnet.mineEmptyBlock(100); // simulate 100 blocks
+
+    // Step 3: Claim rewards
+    const claimResult = await simnet.tx.contractCall({
+      contractAddress: address1,
+      contractName: "stakestream",
+      functionName: "claim-rewards",
+      functionArgs: [],
+      sender: address1,
+    });
+
+    // Step 4: Check that claim succeeded
+    expect(claimResult.success).toBe(true);
+
+    // Optional: check that staking position updated
+    const position = await simnet.callReadOnlyFn(
+      "stakestream",
+      "get-user-position",
+      [simnet.types.principal(address1)],
+      address1
+    );
+
+    expect(position.value["last-claim"]).toBeDefined();
+    expect(position.value["stx-staked"]).toBe(stakeAmount);
+  });
 });


### PR DESCRIPTION
Add reward claiming test for StakeStream contract

- Implements a Vitest test that stakes STX, simulates block progression,  and calls the `claim-rewards` function.
- Verifies successful reward claim and correct update of user staking position.
- Lays foundation for future tests covering tier multipliers and lock-period bonuses.